### PR TITLE
Bugfix 0669648 normalize user input for configset

### DIFF
--- a/fortigate-autoscale/assets/configset/aws/internalelbwebserv
+++ b/fortigate-autoscale/assets/configset/aws/internalelbwebserv
@@ -15,9 +15,9 @@ config firewall vip
         set type fqdn
         set mapped-addr internal-elb-web
         set portforward enable
-        set extintf {EXTERNAL_INTERFACE}
-        set extport {TRAFFIC_PORT}
-        set mappedport {TRAFFIC_PORT}
+        set extintf "{EXTERNAL_INTERFACE}"
+        set extport "{TRAFFIC_PORT}"
+        set mappedport "{TRAFFIC_PORT}"
     next
 end
 

--- a/fortigate-autoscale/assets/configset/aws/setuptgwvpn
+++ b/fortigate-autoscale/assets/configset/aws/setuptgwvpn
@@ -34,7 +34,7 @@ config router prefix-list
     edit "pflist-port1"
         config rule
             edit 1
-                set prefix {@device.networkInterfaces#0.privateIpAddress} 255.255.255.255
+                set prefix "{@device.networkInterfaces#0.privateIpAddress}" 255.255.255.255
                 unset ge
                 unset le
             next
@@ -60,13 +60,13 @@ end
 config vpn ipsec phase1-interface
     edit "tgw-vpn-1"
         set interface "port1"
-        set local-gw {@device.networkInterfaces#0.privateIpAddress}
+        set local-gw "{@device.networkInterfaces#0.privateIpAddress}"
         set dhgrp 2
         set proposal aes128-sha1
         set keylife 28800
         set net-device enable
-        set remote-gw {@vpn_connection.ipsec_tunnel.vpn_gateway.tunnel_outside_address.ip_address}
-        set psksecret {@vpn_connection.ipsec_tunnel.ike.pre_shared_key}
+        set remote-gw "{@vpn_connection.ipsec_tunnel.vpn_gateway.tunnel_outside_address.ip_address}"
+        set psksecret "{@vpn_connection.ipsec_tunnel.ike.pre_shared_key}"
         set dpd-retryinterval 10
         # set transit-gateway command is added in FOS 6.4.2. In any prior FOS version, the 'command fail' errors can be safely ignored if you see them.
         set transit-gateway enable
@@ -87,32 +87,32 @@ end
 config system interface
     edit "tgw-vpn-1"
         set interface "port1"
-        set ip {@vpn_connection.ipsec_tunnel.customer_gateway.tunnel_inside_address.ip_address} 255.255.255.255
+        set ip "{@vpn_connection.ipsec_tunnel.customer_gateway.tunnel_inside_address.ip_address}" 255.255.255.255
         set allowaccess ping
         set type tunnel
         set tcp-mss 1379
-        set remote-ip {@vpn_connection.ipsec_tunnel.vpn_gateway.tunnel_inside_address.ip_address} {@vpn_connection.ipsec_tunnel.vpn_gateway.tunnel_inside_address.network_mask}
+        set remote-ip "{@vpn_connection.ipsec_tunnel.vpn_gateway.tunnel_inside_address.ip_address}" "{@vpn_connection.ipsec_tunnel.vpn_gateway.tunnel_inside_address.network_mask}"
     next
 end
 
 #4: Border Gateway Protocol (BGP) Configuration
 config router bgp
-    set as {@vpn_connection.ipsec_tunnel.customer_gateway.bgp.asn}
-    set router-id {@device.networkInterfaces#0.privateIpAddress}
+    set as "{@vpn_connection.ipsec_tunnel.customer_gateway.bgp.asn}"
+    set router-id "{@device.networkInterfaces#0.privateIpAddress}"
     set ebgp-multipath enable
     set network-import-check disable
     config neighbor
-        edit {@vpn_connection.ipsec_tunnel.vpn_gateway.tunnel_inside_address.ip_address}
+        edit "{@vpn_connection.ipsec_tunnel.vpn_gateway.tunnel_inside_address.ip_address}"
             set capability-default-originate enable
             set link-down-failover enable
             set description "{@vpn_connection.id}-1"
-            set remote-as {@vpn_connection.ipsec_tunnel.vpn_gateway.bgp.asn}
+            set remote-as "{@vpn_connection.ipsec_tunnel.vpn_gateway.bgp.asn}"
             set route-map-out "rmap-outbound"
         next
     end
     config network
         edit 1
-            set prefix {@device.networkInterfaces#0.privateIpAddress} 255.255.255.255
+            set prefix "{@device.networkInterfaces#0.privateIpAddress}" 255.255.255.255
         next
     end
 end
@@ -122,13 +122,13 @@ end
 config vpn ipsec phase1-interface
     edit "tgw-vpn-2"
         set interface "port1"
-        set local-gw {@device.networkInterfaces#0.privateIpAddress}
+        set local-gw "{@device.networkInterfaces#0.privateIpAddress}"
         set dhgrp 2
         set proposal aes128-sha1
         set keylife 28800
         set net-device enable
-        set remote-gw {@vpn_connection.ipsec_tunnel#1.vpn_gateway.tunnel_outside_address.ip_address}
-        set psksecret {@vpn_connection.ipsec_tunnel#1.ike.pre_shared_key}
+        set remote-gw "{@vpn_connection.ipsec_tunnel#1.vpn_gateway.tunnel_outside_address.ip_address}"
+        set psksecret "{@vpn_connection.ipsec_tunnel#1.ike.pre_shared_key}"
         set dpd-retryinterval 10
         # set transit-gateway command is added in FOS 6.4.2. In any prior FOS version, the 'command fail' errors can be safely ignored if you see them.
         set transit-gateway enable
@@ -149,32 +149,32 @@ end
 config system interface
     edit "tgw-vpn-2"
         set interface "port1"
-        set ip {@vpn_connection.ipsec_tunnel#1.customer_gateway.tunnel_inside_address.ip_address} 255.255.255.255
+        set ip "{@vpn_connection.ipsec_tunnel#1.customer_gateway.tunnel_inside_address.ip_address}" 255.255.255.255
         set allowaccess ping
         set type tunnel
         set tcp-mss 1379
-        set remote-ip {@vpn_connection.ipsec_tunnel#1.vpn_gateway.tunnel_inside_address.ip_address} {@vpn_connection.ipsec_tunnel#1.vpn_gateway.tunnel_inside_address.network_mask}
+        set remote-ip "{@vpn_connection.ipsec_tunnel#1.vpn_gateway.tunnel_inside_address.ip_address}" "{@vpn_connection.ipsec_tunnel#1.vpn_gateway.tunnel_inside_address.network_mask}"
     next
 end
 
 #4: Border Gateway Protocol (BGP) Configuration
 config router bgp
-    set as {@vpn_connection.ipsec_tunnel.customer_gateway.bgp.asn}
-    set router-id {@device.networkInterfaces#0.privateIpAddress}
+    set as "{@vpn_connection.ipsec_tunnel.customer_gateway.bgp.asn}"
+    set router-id "{@device.networkInterfaces#0.privateIpAddress}"
     set ebgp-multipath enable
     set network-import-check disable
     config neighbor
-        edit {@vpn_connection.ipsec_tunnel#1.vpn_gateway.tunnel_inside_address.ip_address}
+        edit "{@vpn_connection.ipsec_tunnel#1.vpn_gateway.tunnel_inside_address.ip_address}"
             set capability-default-originate enable
             set link-down-failover enable
             set description "{@vpn_connection.id}-2"
-            set remote-as {@vpn_connection.ipsec_tunnel#1.vpn_gateway.bgp.asn}
+            set remote-as "{@vpn_connection.ipsec_tunnel#1.vpn_gateway.bgp.asn}"
             set route-map-out "rmap-outbound"
         next
     end
     config network
         edit 1
-            set prefix {@device.networkInterfaces#0.privateIpAddress} 255.255.255.255
+            set prefix "{@device.networkInterfaces#0.privateIpAddress}" 255.255.255.255
         next
     end
 end
@@ -183,8 +183,8 @@ end
 
 config firewall ippool
     edit "ippool"
-        set startip {@device.networkInterfaces#0.privateIpAddress}
-        set endip {@device.networkInterfaces#0.privateIpAddress}
+        set startip "{@device.networkInterfaces#0.privateIpAddress}"
+        set endip "{@device.networkInterfaces#0.privateIpAddress}"
     next
 end
 

--- a/fortigate-autoscale/assets/configset/baseconfig
+++ b/fortigate-autoscale/assets/configset/baseconfig
@@ -3,13 +3,13 @@ config system dns
     unset secondary
 end
 config system global
-    set admin-sport {ADMIN_PORT}
+    set admin-sport "{ADMIN_PORT}"
 end
 config system auto-scale
     set status enable
     set sync-interface "{SYNC_INTERFACE}"
-    set hb-interval {HEART_BEAT_INTERVAL}
+    set hb-interval "{HEART_BEAT_INTERVAL}"
     set role master
-    set callback-url {CALLBACK_URL}
-    set psksecret {PSK_SECRET}
+    set callback-url "{CALLBACK_URL}"
+    set psksecret "{PSK_SECRET}"
 end

--- a/fortigate-autoscale/assets/configset/port2config
+++ b/fortigate-autoscale/assets/configset/port2config
@@ -7,7 +7,7 @@ end
 
 config router static
     edit 1
-        set dst {VIRTUAL_NETWORK_CIDR}
+        set dst "{VIRTUAL_NETWORK_CIDR}"
         set device "port2"
         set dynamic-gateway enable
     next

--- a/fortigate-autoscale/fortigate-bootstrap-config-strategy.ts
+++ b/fortigate-autoscale/fortigate-bootstrap-config-strategy.ts
@@ -272,23 +272,40 @@ export class FortiGateBootstrapConfigStrategy implements BootstrapConfigurationS
             config = this.processConfigV2(config, sourceData);
         }
 
-        const psksecret = this.settings.get(FortiGateAutoscaleSetting.FortiGatePskSecret).value;
+        const psksecret = this.normalizeFOSCmdInput(
+            this.settings.get(FortiGateAutoscaleSetting.FortiGatePskSecret).value
+        );
         const syncInterface =
-            this.settings.get(FortiGateAutoscaleSetting.FortiGateSyncInterface).value || 'port1';
+            this.normalizeFOSCmdInput(
+                this.settings.get(FortiGateAutoscaleSetting.FortiGateSyncInterface).value
+            ) || 'port1';
         const trafficPort =
-            this.settings.get(FortiGateAutoscaleSetting.FortiGateTrafficPort).value || '443';
+            this.normalizeFOSCmdInput(
+                this.settings.get(FortiGateAutoscaleSetting.FortiGateTrafficPort).value
+            ) || '443';
         const trafficProtocol =
-            this.settings.get(FortiGateAutoscaleSetting.FortiGateTrafficProtocol).value || 'ALL';
+            this.normalizeFOSCmdInput(
+                this.settings.get(FortiGateAutoscaleSetting.FortiGateTrafficProtocol).value
+            ) || 'ALL';
         const adminPort =
-            this.settings.get(FortiGateAutoscaleSetting.FortiGateAdminPort).value || '8443';
-        const intElbDns = this.settings.get(FortiGateAutoscaleSetting.FortiGateInternalElbDns)
-            .value;
-        const hbInterval = this.settings.get(FortiGateAutoscaleSetting.HeartbeatInterval).value;
+            this.normalizeFOSCmdInput(
+                this.settings.get(FortiGateAutoscaleSetting.FortiGateAdminPort).value
+            ) || '8443';
+        const intElbDns = this.normalizeFOSCmdInput(
+            this.settings.get(FortiGateAutoscaleSetting.FortiGateInternalElbDns).value
+        );
+        const hbInterval = this.normalizeFOSCmdInput(
+            this.settings.get(FortiGateAutoscaleSetting.HeartbeatInterval).value
+        );
         const hbCallbackUrl =
-            this.settings.get(FortiGateAutoscaleSetting.AutoscaleHandlerUrl).value || '';
+            this.normalizeFOSCmdInput(
+                this.settings.get(FortiGateAutoscaleSetting.AutoscaleHandlerUrl).value
+            ) || '';
         const virtualNetworkCidr =
-            this.settings.get(FortiGateAutoscaleSetting.FortiGateAutoscaleVirtualNetworkCidr)
-                .value || '';
+            this.normalizeFOSCmdInput(
+                this.settings.get(FortiGateAutoscaleSetting.FortiGateAutoscaleVirtualNetworkCidr)
+                    .value
+            ) || '';
         return config
             .replace(new RegExp('{SYNC_INTERFACE}', 'gm'), syncInterface)
             .replace(new RegExp('{VIRTUAL_NETWORK_CIDR}', 'gm'), virtualNetworkCidr)
@@ -335,6 +352,16 @@ export class FortiGateBootstrapConfigStrategy implements BootstrapConfigurationS
             // if error occurs, return the original config
             return config;
         }
+    }
+
+    /**
+     * To normalize a string in order for a safe use as the input value for the FOS commands.
+     *
+     * @param {string} input the input string to normalize
+     * @returns {string} the normalized input string
+     */
+    protected normalizeFOSCmdInput(input: string): string {
+        return (input && input.replace(/\\/g, '\\\\').replace(/"/g, '\\"')) || null;
     }
     /**
      * get bootstrap configuration for a FGT vm which's role will be primary

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "autoscale-core",
-    "version": "3.1.1-rc.2",
+    "version": "3.1.1-rc.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "autoscale-core",
     "description": "Fortinet Autoscale project(s), core module.",
-    "version": "3.1.1-rc.2",
+    "version": "3.1.1-rc.3",
     "main": "dist/index.js",
     "types": "dist/types/index.d.ts",
     "scripts": {


### PR DESCRIPTION
fixed #9 (regarding quotation marks in psksecret)
fixed #mantis0669648 (regarding handling replaceable portion of configset)