### PR TITLE
add cloud function peer invocation module

### DIFF
--- a/autoscale-setting.ts
+++ b/autoscale-setting.ts
@@ -8,6 +8,8 @@ import { JSONable } from './jsonable';
  */
 export enum AutoscaleSetting {
     AdditionalConfigSetNameList = 'additional-configset-name-list',
+    AutoscaleFunctionExtendExecution = 'autoscale-function-extend-execution',
+    AutoscaleFunctionMaxExecutionTime = 'autoscale-function-max-execution-time',
     AutoscaleHandlerUrl = 'autoscale-handler-url',
     AssetStorageContainer = 'asset-storage-name',
     AssetStorageDirectory = 'asset-storage-key-prefix',
@@ -174,6 +176,25 @@ export const AutoscaleSettingItemDictionary: SettingItemDictionary = {
             ' are required dependencies for the Autoscale to work for a certain ' +
             ' deployment. Can be left empty.',
         editable: false,
+        jsonEncoded: false,
+        booleanType: false
+    },
+    [AutoscaleSetting.AutoscaleFunctionExtendExecution]: {
+        keyName: AutoscaleSetting.AutoscaleFunctionExtendExecution,
+        description:
+            'Allow one single Autoscale function to be executed in multiple extended invocations' +
+            ' of a cloud platform function if it cannot finish within one invocation and its' +
+            ' functionality supports splitting into extended invocations.',
+        editable: true,
+        jsonEncoded: false,
+        booleanType: true
+    },
+    [AutoscaleSetting.AutoscaleFunctionMaxExecutionTime]: {
+        keyName: AutoscaleSetting.AutoscaleFunctionMaxExecutionTime,
+        description:
+            'Maximum execution time (in second) allowed for an Autoscale Cloud Function that can' +
+            ' run in one cloud function invocation or multiple extended invocations.',
+        editable: true,
         jsonEncoded: false,
         booleanType: false
     },

--- a/cloud-function-peer-invocation.ts
+++ b/cloud-function-peer-invocation.ts
@@ -1,0 +1,44 @@
+import { JSONable } from './jsonable';
+
+export interface CloudFunctionPeerInvocation<TProxy, TPlatform> {
+    proxy: TProxy;
+    platform: TPlatform;
+    executeInvocable(payload: CloudFunctionInvocationPayload, invocable: string): Promise<void>;
+    handleLambdaPeerInvocation(functionEndpoint: string): Promise<void>;
+}
+
+export interface CloudFunctionInvocationPayload extends JSONable {
+    stringifiedData: string;
+    invocable: string;
+    invocationSecretKey: string;
+    executionTime?: number;
+}
+
+export class CloudFunctionInvocationTimeOutError extends Error {
+    extendExecution: boolean;
+    constructor(message?: string, extendExecution = false) {
+        super(message);
+        this.extendExecution = extendExecution;
+    }
+}
+
+export function constructInvocationPayload(
+    payload: unknown,
+    invocable: string,
+    secretKey: string,
+    executionTime?: number
+): CloudFunctionInvocationPayload {
+    const p: CloudFunctionInvocationPayload = {
+        stringifiedData: JSON.stringify(payload),
+        invocable: invocable,
+        invocationSecretKey: secretKey,
+        executionTime: executionTime
+    };
+    return p;
+}
+
+export function extractFromInvocationPayload(
+    invocationPayload: CloudFunctionInvocationPayload
+): unknown {
+    return invocationPayload.stringifiedData && JSON.parse(invocationPayload.stringifiedData);
+}

--- a/cloud-function-proxy.ts
+++ b/cloud-function-proxy.ts
@@ -39,7 +39,12 @@ export interface ReqHeaders {
     [key: string]: unknown;
 }
 
-export type CloudFunctionResponseBody = string | {};
+export type CloudFunctionResponseBody =
+    | string
+    | {}
+    | {
+          [key: string]: unknown;
+      };
 
 export interface CloudFunctionProxyAdapter {
     formatResponse(httpStatusCode: number, body: CloudFunctionResponseBody, headers: {}): {};
@@ -65,6 +70,7 @@ export interface CloudFunctionProxyAdapter {
      * @memberof CloudFunctionProxyAdapter
      */
     getRemainingExecutionTime(): number;
+    getReqBody(): unknown;
 }
 
 export abstract class CloudFunctionProxy<TReq, TContext, TRes>
@@ -101,4 +107,5 @@ export abstract class CloudFunctionProxy<TReq, TContext, TRes>
     ): TRes;
     abstract getRequestAsString(): string;
     abstract getRemainingExecutionTime(): number;
+    abstract getReqBody(): unknown;
 }

--- a/fortigate-autoscale/aws/aws-fortigate-autoscale-settings.ts
+++ b/fortigate-autoscale/aws/aws-fortigate-autoscale-settings.ts
@@ -7,8 +7,6 @@ import {
 // NOTE: every key must start with 'Aws' prefix but the value do not need the prefix
 export const AwsFortiGateAutoscaleSetting = {
     ...FortiGateAutoscaleSetting,
-    AwsAutoscaleFunctionMaxExecutionTime: 'autoscale-function-max-execution-time',
-    AwsAutoscaleFunctionExtendExecution: 'autoscale-function-extend-execution',
     AwsEnableTransitGatewayVpn: 'enable-transit-gateway-vpn',
     AwsLifecycleHookTimeout: 'lifecycle-hook-timeout',
     AwsLoadBalancerTargetGroupArn: 'fortigate-autoscale-target-group-arn',
@@ -20,25 +18,6 @@ export const AwsFortiGateAutoscaleSetting = {
 
 export const AwsFortiGateAutoscaleSettingItemDictionary: SettingItemDictionary = {
     ...FortiGateAutoscaleSettingItemDictionary,
-    [AwsFortiGateAutoscaleSetting.AwsAutoscaleFunctionMaxExecutionTime]: {
-        keyName: AwsFortiGateAutoscaleSetting.AwsAutoscaleFunctionMaxExecutionTime,
-        description:
-            'Maximum execution time (in second) allowed for an Autoscale Cloud Function that can' +
-            ' run in one cloud function invocation or multiple extended invocations.',
-        editable: true,
-        jsonEncoded: false,
-        booleanType: false
-    },
-    [AwsFortiGateAutoscaleSetting.AwsAutoscaleFunctionExtendExecution]: {
-        keyName: AwsFortiGateAutoscaleSetting.AwsAutoscaleFunctionExtendExecution,
-        description:
-            'Allow one single Autoscale function to be executed in multiple extended invocations' +
-            ' of a cloud platform function if it cannot finish within one invocation and its' +
-            ' functionality supports splitting into extended invocations.',
-        editable: true,
-        jsonEncoded: false,
-        booleanType: true
-    },
     [AwsFortiGateAutoscaleSetting.AwsEnableTransitGatewayVpn]: {
         keyName: AwsFortiGateAutoscaleSetting.AwsEnableTransitGatewayVpn,
         description: 'Toggle ON / OFF the Transit Gateway VPN creation on each FortiGate instance',

--- a/fortigate-autoscale/aws/aws-fortigate-faz-integration-strategy.ts
+++ b/fortigate-autoscale/aws/aws-fortigate-faz-integration-strategy.ts
@@ -53,9 +53,7 @@ export class AwsFazReactiveAuthorizationStrategy implements FazIntegrationStrate
         // invoke asynchronously to process this authorization request.
         // the target Lambda function will run the same strategy.
         await this.platform.invokeAutoscaleFunction(
-            {
-                ...payload
-            },
+            payload,
             handlerName,
             AwsLambdaInvocable.TriggerFazDeviceAuth
         );

--- a/fortigate-autoscale/aws/aws-lambda-invocable.ts
+++ b/fortigate-autoscale/aws/aws-lambda-invocable.ts
@@ -1,20 +1,6 @@
-import { JSONable } from '../../jsonable';
+import { FortiGateAutoscaleFunctionInvocable } from '../fortigate-autoscale-function-invocation';
 
-export interface AwsLambdaInvocationPayload extends JSONable {
-    invocable: string;
-    invocationSecretKey: string;
-    executionTime?: number;
-}
-
-export class AwsLambdaInvocableExecutionTimeOutError extends Error {
-    extendExecution: boolean;
-    constructor(message?: string, extendExecution = false) {
-        super(message);
-        this.extendExecution = extendExecution;
-    }
-}
-
-export enum AwsLambdaInvocable {
-    UpdateTgwAttachmentRouteTable = 'UpdateTgwAttachmentRouteTable',
-    TriggerFazDeviceAuth = 'TriggerFazDeviceAuth'
-}
+export const AwsLambdaInvocable = {
+    ...FortiGateAutoscaleFunctionInvocable,
+    UpdateTgwAttachmentRouteTable: 'UpdateTgwAttachmentRouteTable'
+};

--- a/fortigate-autoscale/aws/aws-platform-adapter.ts
+++ b/fortigate-autoscale/aws/aws-platform-adapter.ts
@@ -1,4 +1,8 @@
 import EC2 from 'aws-sdk/clients/ec2';
+import {
+    CloudFunctionInvocationPayload,
+    constructInvocationPayload
+} from '../../cloud-function-peer-invocation';
 import path from 'path';
 
 import { Settings } from '../../autoscale-setting';
@@ -48,7 +52,6 @@ import {
 import { LifecycleItemDbItem } from './aws-db-definitions';
 import * as AwsDBDef from './aws-db-definitions';
 import { AwsFortiGateAutoscaleSetting } from './aws-fortigate-autoscale-settings';
-import { AwsLambdaInvocationPayload } from './aws-lambda-invocable';
 import { AwsPlatformAdaptee } from './aws-platform-adaptee';
 import { AwsVpnAttachmentState, AwsVpnConnection } from './transit-gateway-context';
 
@@ -1672,25 +1675,36 @@ export class AwsPlatformAdapter implements PlatformAdapter {
         this.proxy.logAsInfo('called removePrimaryRoleTag.');
     }
 
-    createAutoscaleFunctionInvocationKey(functionName: string, payload: JSONable): string {
+    createAutoscaleFunctionInvocationKey(
+        payload: unknown,
+        functionName: string,
+        invocable: string
+    ): string {
         const psk = this.settings.get(AwsFortiGateAutoscaleSetting.FortiGatePskSecret).value;
-        return genChecksum(`${functionName}:${psk}:${JSON.stringify(payload)}`, 'sha256');
+        return genChecksum(
+            `${functionName}:${invocable}:${psk}:${JSON.stringify(payload)}`,
+            'sha256'
+        );
     }
 
     async invokeAutoscaleFunction(
-        payload: JSONable,
+        payload: unknown,
         functionEndpoint: string,
         invocable: string,
         executionTime?: number
     ): Promise<number> {
         this.proxy.logAsInfo('calling invokeAutoscaleFunction');
-        const secretKey = this.createAutoscaleFunctionInvocationKey(functionEndpoint, payload);
-        const p: AwsLambdaInvocationPayload = {
-            invocable: invocable,
-            invocationSecretKey: secretKey,
-            executionTime: executionTime
-        };
-        Object.assign(p, payload);
+        const secretKey = this.createAutoscaleFunctionInvocationKey(
+            payload,
+            functionEndpoint,
+            invocable
+        );
+        const p: CloudFunctionInvocationPayload = constructInvocationPayload(
+            payload,
+            invocable,
+            secretKey,
+            executionTime
+        );
         const response = await this.adaptee.invokeLambda(
             functionEndpoint,
             'Event',

--- a/fortigate-autoscale/aws/aws-tgw-vpn-attachment-strategy.ts
+++ b/fortigate-autoscale/aws/aws-tgw-vpn-attachment-strategy.ts
@@ -1,3 +1,4 @@
+import { CloudFunctionInvocationTimeOutError } from '../../cloud-function-peer-invocation';
 import { CloudFunctionProxyAdapter } from '../../cloud-function-proxy';
 import {
     VpnAttachmentStrategy,
@@ -12,10 +13,7 @@ import {
 import { ResourceFilter, TgwVpnAttachmentRecord } from '../../platform-adapter';
 import { VirtualMachine } from '../../virtual-machine';
 import { AwsFortiGateAutoscaleSetting } from './aws-fortigate-autoscale-settings';
-import {
-    AwsLambdaInvocable,
-    AwsLambdaInvocableExecutionTimeOutError
-} from './aws-lambda-invocable';
+import { AwsLambdaInvocable } from './aws-lambda-invocable';
 import { AwsPlatformAdapter } from './aws-platform-adapter';
 import {
     AwsTgwVpnUpdateAttachmentRouteTableRequest,
@@ -213,9 +211,7 @@ export class AwsTgwVpnAttachmentStrategy implements VpnAttachmentStrategy {
             AwsFortiGateAutoscaleSetting.AwsTransitGatewayVpnHandlerName
         ).value;
         await this.platform.invokeAutoscaleFunction(
-            {
-                ...request
-            },
+            request,
             handlerName,
             AwsLambdaInvocable.UpdateTgwAttachmentRouteTable
         );
@@ -298,7 +294,7 @@ export class AwsTgwVpnAttachmentStrategy implements VpnAttachmentStrategy {
                 callCount * waitForInterval >
                 this.proxy.getRemainingExecutionTime() - timeBeforeRemainingExecution
             ) {
-                throw new AwsLambdaInvocableExecutionTimeOutError(
+                throw new CloudFunctionInvocationTimeOutError(
                     'Execution timeout. Maximum amount of waiting time:' +
                         ` ${(callCount * waitForInterval) / 1000} seconds, have been reached.`
                 );

--- a/fortigate-autoscale/fortigate-autoscale-function-invocation.ts
+++ b/fortigate-autoscale/fortigate-autoscale-function-invocation.ts
@@ -1,0 +1,119 @@
+import {
+    CloudFunctionInvocationPayload,
+    CloudFunctionInvocationTimeOutError,
+    CloudFunctionPeerInvocation,
+    extractFromInvocationPayload
+} from '../cloud-function-peer-invocation';
+import { CloudFunctionProxyAdapter, ReqType } from '../cloud-function-proxy';
+import { PlatformAdapter } from '../platform-adapter';
+import { FortiGateAutoscaleSetting } from './fortigate-autoscale-settings';
+
+export const FortiGateAutoscaleFunctionInvocable = {
+    TriggerFazDeviceAuth: 'TriggerFazDeviceAuth'
+};
+
+export abstract class FortiGateAutoscaleFunctionInvocationHandler
+    implements CloudFunctionPeerInvocation<CloudFunctionProxyAdapter, PlatformAdapter> {
+    abstract get proxy(): CloudFunctionProxyAdapter;
+    abstract get platform(): PlatformAdapter;
+    abstract executeInvocable(
+        payload: CloudFunctionInvocationPayload,
+        invocable: string
+    ): Promise<void>;
+
+    async handleLambdaPeerInvocation(functionEndpoint: string): Promise<void> {
+        this.proxy.logAsInfo('calling handleLambdaPeerInvocation.');
+        try {
+            // init the platform. this step is important
+            await this.platform.init();
+            const requestType = await this.platform.getRequestType();
+            const settings = await this.platform.getSettings();
+            if (requestType !== ReqType.CloudFunctionPeerInvocation) {
+                this.proxy.logAsWarning('Not a CloudFunctionPeerInvocation type request. Skip it.');
+                this.proxy.logAsInfo('called handleLambdaPeerInvocation.');
+                return;
+            }
+            // get the invocation payload
+            const invocationPayload: CloudFunctionInvocationPayload = this.proxy.getReqBody() as CloudFunctionInvocationPayload;
+            if (!invocationPayload) {
+                throw new Error('Invalid request body.');
+            }
+
+            // authentication verification
+            const payload: unknown = extractFromInvocationPayload(invocationPayload);
+            const invocationSecretKey = this.platform.createAutoscaleFunctionInvocationKey(
+                payload,
+                functionEndpoint,
+                invocationPayload.invocable
+            );
+
+            // verify the invocation key
+            if (!invocationSecretKey || invocationSecretKey !== invocationPayload.secretKey) {
+                throw new Error('Invalid invocation payload: invocationSecretKey not matched');
+            }
+            const currentExecutionStartTime = Date.now(); // ms
+            const extendExecution = settings.get(
+                FortiGateAutoscaleSetting.AutoscaleFunctionExtendExecution
+            );
+            const shouldExtendExecution: boolean = extendExecution && extendExecution.truthValue;
+            try {
+                await this.executeInvocable(invocationPayload, invocationPayload.invocable);
+            } catch (e) {
+                if (
+                    e instanceof CloudFunctionInvocationTimeOutError &&
+                    e.extendExecution &&
+                    shouldExtendExecution
+                ) {
+                    const maxExecutionTimeItem = settings.get(
+                        FortiGateAutoscaleSetting.AutoscaleFunctionMaxExecutionTime
+                    );
+                    // the maximum execution time allowed for a cloud function
+                    // NOTE: the time is set in second.
+                    const maxExecutionTime =
+                        maxExecutionTimeItem && Number(maxExecutionTimeItem.value);
+
+                    // time taken in preceeding relevent invocations and time taken in
+                    // current invocation.
+                    // NOTE: this time is also in second.
+                    const totalExecutionTime =
+                        Math.floor((Date.now() - currentExecutionStartTime) / 1000) +
+                        invocationPayload.executionTime;
+
+                    // if max execution time not reached, create a new invocation to continue
+                    if (totalExecutionTime < maxExecutionTime) {
+                        await this.platform.invokeAutoscaleFunction(
+                            payload,
+                            functionEndpoint,
+                            invocationPayload.invocable,
+                            // carry the total execution time to the next call.
+                            totalExecutionTime
+                        );
+                        this.proxy.logAsInfo(
+                            'AutoscaleFunctionExtendExecution is enabled.' +
+                                ` Current total execution time is: ${totalExecutionTime} seconds.` +
+                                ` Max execution time allowed is: ${maxExecutionTime} seconds.` +
+                                ' Now invoke a new Lambda function to continue.'
+                        );
+                    } else {
+                        this.proxy.logAsError(
+                            'AutoscaleFunctionExtendExecution is enabled.' +
+                                ` Current total execution time is: ${totalExecutionTime} seconds.` +
+                                ` Max execution time allowed is: ${maxExecutionTime} seconds.` +
+                                ' No more time allowed to wait so it timed out and failed.'
+                        );
+                        // extended execution reached max execution time allowed.
+                        throw e;
+                    }
+                } else {
+                    // not a CloudFunctionInvocationTimeOutError or not allow to extend execution.
+                    throw e;
+                }
+            }
+            this.proxy.logAsInfo('called handleLambdaPeerInvocation.');
+            return;
+        } catch (error) {
+            // ASSERT: error is always an instance of Error
+            this.proxy.logForError('called handleLambdaPeerInvocation.', error);
+        }
+    }
+}

--- a/platform-adapter.ts
+++ b/platform-adapter.ts
@@ -145,4 +145,36 @@ export interface PlatformAdapter {
         primary: boolean,
         vip: string
     ): Promise<void>;
+
+    /**
+     * invoke the Autoscale handler function
+     * @param  {unknown} payload the payload to invoke the function
+     * @param  {string} functionEndpoint the function name or fqdn of the function which is
+     * depending on implementation.
+     * @param  {string} invocable the pre-defined type name of features that is invocable in this
+     * way.
+     * @param  {number} executionTime? the accumulative execution time of one complete invocation.
+     * due to cloud platform limitation, one complete invocation may have to split into two or more
+     * function calls in order to get the final result.
+     * @returns Promise
+     */
+    invokeAutoscaleFunction(
+        payload: unknown,
+        functionEndpoint: string,
+        invocable: string,
+        executionTime?: number
+    ): Promise<number>;
+
+    /**
+     * create an invocation key for authentication between Autoscale Function caller and receiver.
+     * @param  {unknown} payload
+     * @param  {string} functionEndpoint
+     * @param  {string} invocable
+     * @returns string
+     */
+    createAutoscaleFunctionInvocationKey(
+        payload: unknown,
+        functionEndpoint: string,
+        invocable: string
+    ): string;
 }

--- a/test/fortigate-autoscale/aws/aws-api.spec.ts
+++ b/test/fortigate-autoscale/aws/aws-api.spec.ts
@@ -1,11 +1,11 @@
 /* eslint-disable prefer-const */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import AutoScaling from 'aws-sdk/clients/autoscaling';
+import { DocumentClient } from 'aws-sdk/clients/dynamodb';
 import EC2 from 'aws-sdk/clients/ec2';
 import ELBv2 from 'aws-sdk/clients/elbv2';
 import Lambda from 'aws-sdk/clients/lambda';
 import S3 from 'aws-sdk/clients/s3';
-import { DocumentClient } from 'aws-sdk/clients/dynamodb';
 import fs from 'fs';
 import { describe, it } from 'mocha';
 import path from 'path';
@@ -38,6 +38,9 @@ class TestCloudFunctionProxyAdapter implements CloudFunctionProxyAdapter {
     private executionStartTime: number;
     constructor() {
         this.executionStartTime = Date.now();
+    }
+    getReqBody(): unknown {
+        return 'fake-body-as-string';
     }
     getRequestAsString(): string {
         return 'fake-req-as-string';

--- a/test/sanity-test.spec.ts
+++ b/test/sanity-test.spec.ts
@@ -13,16 +13,26 @@ import {
 import {
     ConstantIntervalHeartbeatSyncStrategy,
     HeartbeatSyncStrategy,
-    PrimaryElectionStrategy,
-    PrimaryElectionStrategyResult,
     NoopTaggingVmStrategy,
-    PreferredGroupPrimaryElection
+    PreferredGroupPrimaryElection,
+    PrimaryElectionStrategy,
+    PrimaryElectionStrategyResult
 } from '../context-strategy/autoscale-context';
 import {
     NoopScalingGroupStrategy,
     ScalingGroupStrategy
 } from '../context-strategy/scaling-group-context';
+import { AwsFortiGateAutoscaleSetting } from '../fortigate-autoscale/aws/aws-fortigate-autoscale-settings';
 import { FortiGateAutoscaleSetting } from '../fortigate-autoscale/fortigate-autoscale-settings';
+import { NoopFazIntegrationStrategy } from '../fortigate-autoscale/fortigate-faz-integration-strategy';
+import { compare } from '../helper-function';
+import {
+    LicenseFile,
+    LicenseStockRecord,
+    LicenseUsageRecord,
+    PlatformAdapter,
+    ResourceFilter
+} from '../platform-adapter';
 import {
     HealthCheckRecord,
     HealthCheckResult,
@@ -31,17 +41,7 @@ import {
     PrimaryRecord,
     PrimaryRecordVoteState
 } from '../primary-election';
-import {
-    LicenseFile,
-    LicenseStockRecord,
-    LicenseUsageRecord,
-    PlatformAdapter,
-    ResourceFilter
-} from '../platform-adapter';
 import { NetworkInterface, VirtualMachine, VirtualMachineState } from '../virtual-machine';
-import { compare } from '../helper-function';
-import { AwsFortiGateAutoscaleSetting } from '../fortigate-autoscale/aws/aws-fortigate-autoscale-settings';
-import { NoopFazIntegrationStrategy } from '../fortigate-autoscale/fortigate-faz-integration-strategy';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 
@@ -100,6 +100,21 @@ class TestAutoscale extends Autoscale {
 }
 
 class TestPlatformAdapter implements PlatformAdapter {
+    invokeAutoscaleFunction(
+        payload: unknown,
+        functionEndpoint: string,
+        invocable: string,
+        executionTime?: number
+    ): Promise<number> {
+        return Promise.resolve(0);
+    }
+    createAutoscaleFunctionInvocationKey(
+        payload: unknown,
+        functionEndpoint: string,
+        invocable: string
+    ): string {
+        return '';
+    }
     saveSettingItem(
         key: string,
         value: string,
@@ -249,6 +264,9 @@ class TestCloudFunctionProxyAdapter implements CloudFunctionProxyAdapter {
     private executionStartTime: number;
     constructor() {
         this.executionStartTime = Date.now();
+    }
+    getReqBody(): unknown {
+        return 'fake-body-as-string';
     }
     getRemainingExecutionTime(): number {
         // set it to 60 seconds


### PR DESCRIPTION
The cloud function peer invocation was initially developed for Autoscale AWS.
Now the functionality can be extended to multiple platforms so it's the reason to convert it into a feature module.

No impact on the dependent project by this change.

Will publish as a small patch under 3.1