### PR TITLE
aws tgw vpn ipsec use dhgrp 14 and proposal aes128-sha256

### DIFF
--- a/fortigate-autoscale/assets/configset/aws/setuptgwvpn
+++ b/fortigate-autoscale/assets/configset/aws/setuptgwvpn
@@ -61,8 +61,8 @@ config vpn ipsec phase1-interface
     edit "tgw-vpn-1"
         set interface "port1"
         set local-gw "{@device.networkInterfaces#0.privateIpAddress}"
-        set dhgrp 2
-        set proposal aes128-sha1
+        set dhgrp 14
+        set proposal aes128-sha256
         set keylife 28800
         set net-device enable
         set remote-gw "{@vpn_connection.ipsec_tunnel.vpn_gateway.tunnel_outside_address.ip_address}"
@@ -77,8 +77,8 @@ end
 config vpn ipsec phase2-interface
     edit "tgw-vpn-1"
         set phase1name "tgw-vpn-1"
-        set proposal aes128-sha1
-        set dhgrp 2
+        set proposal aes128-sha256
+        set dhgrp 14
         set keylifeseconds 3600
     next
 end
@@ -123,8 +123,8 @@ config vpn ipsec phase1-interface
     edit "tgw-vpn-2"
         set interface "port1"
         set local-gw "{@device.networkInterfaces#0.privateIpAddress}"
-        set dhgrp 2
-        set proposal aes128-sha1
+        set dhgrp 14
+        set proposal aes128-sha256
         set keylife 28800
         set net-device enable
         set remote-gw "{@vpn_connection.ipsec_tunnel#1.vpn_gateway.tunnel_outside_address.ip_address}"
@@ -139,8 +139,8 @@ end
 config vpn ipsec phase2-interface
     edit "tgw-vpn-2"
         set phase1name "tgw-vpn-2"
-        set proposal aes128-sha1
-        set dhgrp 2
+        set proposal aes128-sha256
+        set dhgrp 14
         set keylifeseconds 3600
     next
 end

--- a/test/fortigate-autoscale/aws/mockup-data/aws-api/s3/assets/configset/setuptgwvpn
+++ b/test/fortigate-autoscale/aws/mockup-data/aws-api/s3/assets/configset/setuptgwvpn
@@ -61,8 +61,8 @@ config vpn ipsec phase1-interface
     edit "tgw-vpn-1"
         set interface "port1"
         set local-gw {@device.networkInterfaces#0.privateIpAddress}
-        set dhgrp 2
-        set proposal aes128-sha1
+        set dhgrp 14
+        set proposal aes128-sha256
         set keylife 28800
         set net-device enable
         set remote-gw {@vpn_connection.ipsec_tunnel.vpn_gateway.tunnel_outside_address.ip_address}
@@ -75,8 +75,8 @@ end
 config vpn ipsec phase2-interface
     edit "tgw-vpn-1"
         set phase1name "tgw-vpn-1"
-        set proposal aes128-sha1
-        set dhgrp 2
+        set proposal aes128-sha256
+        set dhgrp 14
         set keylifeseconds 3600
     next
 end
@@ -121,8 +121,8 @@ config vpn ipsec phase1-interface
     edit "tgw-vpn-2"
         set interface "port1"
         set local-gw {@device.networkInterfaces#0.privateIpAddress}
-        set dhgrp 2
-        set proposal aes128-sha1
+        set dhgrp 14
+        set proposal aes128-sha256
         set keylife 28800
         set net-device enable
         set remote-gw {@vpn_connection.ipsec_tunnel#1.vpn_gateway.tunnel_outside_address.ip_address}
@@ -135,8 +135,8 @@ end
 config vpn ipsec phase2-interface
     edit "tgw-vpn-2"
         set phase1name "tgw-vpn-2"
-        set proposal aes128-sha1
-        set dhgrp 2
+        set proposal aes128-sha256
+        set dhgrp 14
         set keylifeseconds 3600
     next
 end

--- a/test/fortigate-autoscale/aws/mockup-data/aws-cfn-service-provider/aws-api/s3/assets/configset/setuptgwvpn
+++ b/test/fortigate-autoscale/aws/mockup-data/aws-cfn-service-provider/aws-api/s3/assets/configset/setuptgwvpn
@@ -61,8 +61,8 @@ config vpn ipsec phase1-interface
     edit "tgw-vpn-1"
         set interface "port1"
         set local-gw {@device.networkInterfaces#0.privateIpAddress}
-        set dhgrp 2
-        set proposal aes128-sha1
+        set dhgrp 14
+        set proposal aes128-sha256
         set keylife 28800
         set net-device enable
         set remote-gw {@vpn_connection.ipsec_tunnel.vpn_gateway.tunnel_outside_address.ip_address}
@@ -75,8 +75,8 @@ end
 config vpn ipsec phase2-interface
     edit "tgw-vpn-1"
         set phase1name "tgw-vpn-1"
-        set proposal aes128-sha1
-        set dhgrp 2
+        set proposal aes128-sha256
+        set dhgrp 14
         set keylifeseconds 3600
     next
 end
@@ -121,8 +121,8 @@ config vpn ipsec phase1-interface
     edit "tgw-vpn-2"
         set interface "port1"
         set local-gw {@device.networkInterfaces#0.privateIpAddress}
-        set dhgrp 2
-        set proposal aes128-sha1
+        set dhgrp 14
+        set proposal aes128-sha256
         set keylife 28800
         set net-device enable
         set remote-gw {@vpn_connection.ipsec_tunnel#1.vpn_gateway.tunnel_outside_address.ip_address}
@@ -135,8 +135,8 @@ end
 config vpn ipsec phase2-interface
     edit "tgw-vpn-2"
         set phase1name "tgw-vpn-2"
-        set proposal aes128-sha1
-        set dhgrp 2
+        set proposal aes128-sha256
+        set dhgrp 14
         set keylifeseconds 3600
     next
 end

--- a/test/fortigate-autoscale/mockup-data/integrity-check/aws-api/s3/assets/configset/setuptgwvpn
+++ b/test/fortigate-autoscale/mockup-data/integrity-check/aws-api/s3/assets/configset/setuptgwvpn
@@ -61,8 +61,8 @@ config vpn ipsec phase1-interface
     edit "tgw-vpn-1"
         set interface "port1"
         set local-gw {@device.networkInterfaces#0.privateIpAddress}
-        set dhgrp 2
-        set proposal aes128-sha1
+        set dhgrp 14
+        set proposal aes128-sha256
         set keylife 28800
         set net-device enable
         set remote-gw {@vpn_connection.ipsec_tunnel.vpn_gateway.tunnel_outside_address.ip_address}
@@ -75,8 +75,8 @@ end
 config vpn ipsec phase2-interface
     edit "tgw-vpn-1"
         set phase1name "tgw-vpn-1"
-        set proposal aes128-sha1
-        set dhgrp 2
+        set proposal aes128-sha256
+        set dhgrp 14
         set keylifeseconds 3600
     next
 end
@@ -121,8 +121,8 @@ config vpn ipsec phase1-interface
     edit "tgw-vpn-2"
         set interface "port1"
         set local-gw {@device.networkInterfaces#0.privateIpAddress}
-        set dhgrp 2
-        set proposal aes128-sha1
+        set dhgrp 14
+        set proposal aes128-sha256
         set keylife 28800
         set net-device enable
         set remote-gw {@vpn_connection.ipsec_tunnel#1.vpn_gateway.tunnel_outside_address.ip_address}
@@ -135,8 +135,8 @@ end
 config vpn ipsec phase2-interface
     edit "tgw-vpn-2"
         set phase1name "tgw-vpn-2"
-        set proposal aes128-sha1
-        set dhgrp 2
+        set proposal aes128-sha256
+        set dhgrp 14
         set keylifeseconds 3600
     next
 end


### PR DESCRIPTION
this patch:
AWS transit gateway vpn ipsec phase 2 will use dhgrp 14 and proposal aes128-sha256.

This change was originally for the US Gov Cloud support which requires a higher security standard.

We could apply this setting as default in Autoscale (AWS) project wide.

This PR targets version 3.1.3, and will be bringing the above patch into the staging_3.1.3-rc.0 branch for the next release QA.