### PR TITLE
Patch refine exports in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Autoscale Core
+
+[![version on main branch](https://img.shields.io/github/package-json/v/fortinet/autoscale-core?label=version%20on%20main%20branch)](./) [![latest release version](https://img.shields.io/github/v/release/fortinet/autoscale-core?label=latest%20release%20version)](https://github.com/fortinet/autoscale-core/releases/latest) [![platform](https://img.shields.io/badge/platform-AWS%20|%20Azure-green.svg)](./)
+
 Autoscale Core is the core library for the Fortinet Autoscale project.
 
 The Fortinet Autoscale project provides cloud-based multi-group auto scaling functionality for virtual machines of Fortinet products that have native HA features to form a cluster with failover protection.
@@ -6,12 +9,14 @@ The Fortinet Autoscale project provides cloud-based multi-group auto scaling fun
 This project provides the core logic of a hybrid licensing architecture and provides an interface that can be extended to deal with the differences in cloud platform APIs.
 
 This project has the following features:
- * Multi-group licensing models: Bring Your Own License (BYOL)-Only, Pay As You Go (PAYG)-Only, and Hybrid (any combination of BYOL and PAYG).
- * AWS Transit Gateway integration (see: https://github.com/fortinet/fortigate-autoscale-aws)
 
+* Multi-group licensing models: Bring Your Own License (BYOL)-Only, Pay As You Go (PAYG)-Only, and Hybrid (any combination of BYOL and PAYG).
+* AWS Transit Gateway integration (see: [https://github.com/fortinet/fortigate-autoscale-aws](https://github.com/fortinet/fortigate-autoscale-aws))
 
 ## Supported platforms
+
 This project supports auto scaling for the cloud platforms listed below:
+
 * Amazon AWS
 
 ## Installation
@@ -24,8 +29,10 @@ This project can be used as a NodeJS dependency. To install using NPM, run the f
 
 Technical diagrams are available in the [docs/diagrams](./docs/diagrams) directory.
 
-# Support
+## Support
+
 Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services. For direct issues, please refer to the [Issues](https://github.com/fortinet/autoscale-core/issues) tab of this GitHub project. For other questions related to this project, contact  [github@fortinet.com](mailto:github@fortinet.com).
 
 ## License
+
 [License](./LICENSE) © Fortinet Technologies. All rights reserved.

--- a/fortigate-autoscale/package-lock.json
+++ b/fortigate-autoscale/package-lock.json
@@ -1890,9 +1890,9 @@
       }
     },
     "underscore": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
-      "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "universal-user-agent": {
       "version": "6.0.0",

--- a/fortigate-autoscale/package.json
+++ b/fortigate-autoscale/package.json
@@ -5,7 +5,8 @@
     "main": "./dist/index.js",
     "exports": {
         ".": "./dist/index.js",
-        "./azure": "./dist/azure/index.js"
+        "./azure/": "./dist/azure/",
+        "./aws/": "./dist/aws/"
     },
     "types": "./dist/index.d.ts",
     "files": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1686,9 +1686,9 @@
             "dev": true
         },
         "hosted-git-info": {
-            "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-            "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
             "dev": true
         },
         "http-status-codes": {
@@ -2680,14 +2680,22 @@
             }
         },
         "postcss": {
-            "version": "8.2.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
-            "integrity": "sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.0.tgz",
+            "integrity": "sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==",
             "dev": true,
             "requires": {
                 "colorette": "^1.2.2",
-                "nanoid": "^3.1.20",
-                "source-map": "^0.6.1"
+                "nanoid": "^3.1.23",
+                "source-map-js": "^0.6.2"
+            },
+            "dependencies": {
+                "nanoid": {
+                    "version": "3.1.23",
+                    "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+                    "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+                    "dev": true
+                }
             }
         },
         "postcss-modules-extract-imports": {
@@ -3097,6 +3105,12 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true
+        },
+        "source-map-js": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+            "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
             "dev": true
         },
         "source-map-support": {


### PR DESCRIPTION
refine the package.json for fortigate-autoscale to allow for importing ts modules in a sub path.

also apply node dependency security update.

should bump the version at patch level.