### PR TITLE
out-of-sync message never logs. Add logging so that message will also…

### DIFF
--- a/core/autoscale-core.ts
+++ b/core/autoscale-core.ts
@@ -488,9 +488,12 @@ export abstract class Autoscale implements AutoscaleCore {
         const vmHandler = async (vm: VirtualMachine): Promise<void> => {
             this.proxy.logAsInfo(`handling unhealthy vm(id: ${vm.id})...`);
             const subject = 'Autoscale unhealthy vm is detected';
-            let message =
+
+            let message;
+            this.proxy.logAsWarning(
                 `Device (id: ${vm.id}, ip: ${vm.primaryPrivateIpAddress}) has` +
-                ' been deemed unhealthy and marked as out-of-sync by the Autoscale.\n\n';
+                    ' been deemed unhealthy and marked as out-of-sync by the Autoscale.\n\n'
+            );
             this.proxy.logAsWarning(
                 'Termination of unhealthy vm is ' +
                     `${terminateUnhealthyVm ? 'enabled' : 'disabled'}.` +


### PR DESCRIPTION
Changes never used message to log so we see that in the output of app insights etc.

This change could just be added into one of the other current builds, or done after those have been completed.